### PR TITLE
Added SVG to compressible mime types

### DIFF
--- a/tornado/web.py
+++ b/tornado/web.py
@@ -2713,7 +2713,8 @@ class GZipContentEncoding(OutputTransform):
     # beginning with "text/").
     CONTENT_TYPES = set(["application/javascript", "application/x-javascript",
                          "application/xml", "application/atom+xml",
-                         "application/json", "application/xhtml+xml"])
+                         "application/json", "application/xhtml+xml",
+                         "image/svg+xml"])
     # Python's GzipFile defaults to level 9, while most other gzip
     # tools (including gzip itself) default to 6, which is probably a
     # better CPU/size tradeoff.


### PR DESCRIPTION
This adds the mime type `image/svg+xml` to the whitelist of compressible mime types for the `tornado.web.GZipContentEncoding` class.

SVG images are served with the mime type `image/svg+xml`, but are not compressed by the GZipContentEncoding transform. My first thought was to add all mime types ending with `+xml`, but that might need a bit more research.